### PR TITLE
Fix renormalization when saving and loading checkpoints

### DIFF
--- a/src/tenso/prototypes/heom.py
+++ b/src/tenso/prototypes/heom.py
@@ -139,9 +139,12 @@ def system_single_bath(
     if parameters['load_checkpoint_from_file']:
         state = Model.load(fname + default_extension['checkpoint'])
         hierarchy.initialize_from_chk() # Set up terminators etc
-        renorm_coeff = state[root].norm()
-        state.update({root: state[root] / renorm_coeff})
-        renorm_coeff = opt_to_numpy(renorm_coeff)
+        if parameters['renormalize']:
+            renorm_coeff = state[root].norm()
+            state.update({root: state[root] / renorm_coeff})
+            renorm_coeff = opt_to_numpy(renorm_coeff)
+        else:
+            renorm_coeff = 1.0
     else:
         state = hierarchy.initialize_state(init_rdo, rank)
         renorm_coeff = 1.0
@@ -275,7 +278,7 @@ def system_single_bath(
 
     if parameters['save_checkpoint_to_file']:
         if parameters['renormalize']:
-            state.update({root: root_array * renorm_coeff})
+            state.update({root: state[root] * renorm_coeff})
         state.save(fname + default_extension['checkpoint'])
     return
 
@@ -407,9 +410,12 @@ def system_multibath(
     if parameters['load_checkpoint_from_file']:
         state = Model.load(fname + default_extension['checkpoint'])
         hierarchy.initialize_from_chk() # Set up terminators etc
-        renorm_coeff = state[root].norm()
-        state.update({root: state[root] / renorm_coeff})
-        renorm_coeff = opt_to_numpy(renorm_coeff)
+        if parameters['renormalize']:
+            renorm_coeff = state[root].norm()
+            state.update({root: state[root] / renorm_coeff})
+            renorm_coeff = opt_to_numpy(renorm_coeff)
+        else:
+            renorm_coeff = 1.0
     else:
         state = hierarchy.initialize_state(init_rdo, rank)
         renorm_coeff = 1.0
@@ -542,7 +548,7 @@ def system_multibath(
 
     if parameters['save_checkpoint_to_file']:
         if parameters['renormalize']:
-            state.update({root: root_array * renorm_coeff})
+            state.update({root: state[root] * renorm_coeff})
         state.save(fname + default_extension['checkpoint'])
     return
 

--- a/src/tenso/prototypes/mctdh.py
+++ b/src/tenso/prototypes/mctdh.py
@@ -106,9 +106,12 @@ def system_single_bath(
     rank = parameters['rank']
     if parameters['load_checkpoint_from_file']:
         state = Model.load(fname + default_extension['checkpoint'])
-        renorm_coeff = state[root].norm()
-        state.update({root: state[root] / renorm_coeff})
-        renorm_coeff = opt_to_numpy(renorm_coeff)
+        if parameters['renormalize']:
+            renorm_coeff = state[root].norm()
+            state.update({root: state[root] / renorm_coeff})
+            renorm_coeff = opt_to_numpy(renorm_coeff)
+        else:
+            renorm_coeff = 1.0
         hierarchy.initialize_from_chk() # Set up terminators etc
     else:
         state = hierarchy.initialize_pure_state([init_wfn],
@@ -223,7 +226,7 @@ def system_single_bath(
 
     if parameters['save_checkpoint_to_file']:
         if parameters['renormalize']:
-            state.update({root: root_array * renorm_coeff})
+            state.update({root: state[root] * renorm_coeff})
         state.save(fname + default_extension['checkpoint'])
     return
 
@@ -311,9 +314,12 @@ def system_single_bath_q(
     rank = parameters['rank']
     if parameters['load_checkpoint_from_file']:
         state = Model.load(fname + default_extension['checkpoint'])
-        renorm_coeff = state[root].norm()
-        state.update({root: state[root] / renorm_coeff})
-        renorm_coeff = opt_to_numpy(renorm_coeff)
+        if parameters['renormalize']:
+            renorm_coeff = state[root].norm()
+            state.update({root: state[root] / renorm_coeff})
+            renorm_coeff = opt_to_numpy(renorm_coeff)
+        else:
+            renorm_coeff = 1.0
         hierarchy.initialize_from_chk() # Set up terminators etc
     else:
         state = hierarchy.initialize_pure_state([init_wfn],
@@ -452,7 +458,7 @@ def system_single_bath_q(
 
     if parameters['save_checkpoint_to_file']:
         if parameters['renormalize']:
-            state.update({root: root_array * renorm_coeff})
+            state.update({root: state[root] * renorm_coeff})
         state.save(fname + default_extension['checkpoint'])
     return
 
@@ -545,9 +551,12 @@ def system_multibath(
     rank = parameters['rank']
     if parameters['load_checkpoint_from_file']:
         state = Model.load(fname + default_extension['checkpoint'])
-        renorm_coeff = state[root].norm()
-        state.update({root: state[root] / renorm_coeff})
-        renorm_coeff = opt_to_numpy(renorm_coeff)
+        if parameters['renormalize']:
+            renorm_coeff = state[root].norm()
+            state.update({root: state[root] / renorm_coeff})
+            renorm_coeff = opt_to_numpy(renorm_coeff)
+        else:
+            renorm_coeff = 1.0
         hierarchy.initialize_from_chk() # Set up terminators etc
     else:
         state = hierarchy.initialize_pure_state([init_wfn],
@@ -659,6 +668,6 @@ def system_multibath(
 
     if parameters['save_checkpoint_to_file']:
         if parameters['renormalize']:
-            state.update({root: root_array * renorm_coeff})
+            state.update({root: state[root] * renorm_coeff})
         state.save(fname + default_extension['checkpoint'])
     return


### PR DESCRIPTION
Fixed a bug when saving checkpoints where a stale root array was used to undo normalization prior to writing to disk. Also, keep renorm_coeff at 1.0 when loading checkpoints if renormalization is not set.